### PR TITLE
Chat/sendmsg

### DIFF
--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -26,10 +26,14 @@ export default function ChatRoom() {
     const { chatRooms, isInited, refreshChatRooms } = useChatRooms(
         data?.idToken
     )
-    const { socket, allUsers, userCount, socketError, clearSocketError } =
-        useSocket(data?.idToken)
-
-    // ...existing code...
+    const {
+        socket,
+        allUsers,
+        userCount,
+        socketError,
+        clearSocketError,
+        messages,
+    } = useSocket(data?.idToken)
 
     // Initialize sticker functionality
     const activeRoomData = chatRooms.find((r) => r.id === activeRoom)
@@ -118,6 +122,9 @@ export default function ChatRoom() {
                 <ChatSection
                     activeRoomData={activeRoomData}
                     openStickerModal={openStickerModal}
+                    socket={socket}
+                    currentUser={currentUser}
+                    messages={messages}
                 />
 
                 {/* Online Users Panel */}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -26,8 +26,14 @@ export default function YOTTChatRooms() {
     const { chatRooms, isInited, refreshChatRooms } = useChatRooms(
         data?.idToken
     )
-    const { socket, allUsers, userCount, socketError, clearSocketError } =
-        useSocket(data?.idToken)
+    const {
+        socket,
+        allUsers,
+        userCount,
+        socketError,
+        clearSocketError,
+        messages,
+    } = useSocket(data?.idToken)
 
     // ...existing code...
 

--- a/src/components/hook/useSocket.ts
+++ b/src/components/hook/useSocket.ts
@@ -6,6 +6,7 @@ export function useSocket(token?: string) {
     const [allUsers, setAllUsers] = useState<any[]>([])
     const [userCount, setUserCount] = useState<number>(0)
     const [socketError, setSocketError] = useState<string | null>(null)
+    const [messages, setMessages] = useState<any[]>([])
 
     useEffect(() => {
         if (!token) return
@@ -55,7 +56,10 @@ export function useSocket(token?: string) {
             console.error("Chat creation error:", error)
             setSocketError(error.message || "Failed to create chat")
         })
-
+        socketConnection.on("receive_msg", (messageData) => {
+            console.log("Received message:", messageData)
+            setMessages((prev) => [...prev, messageData])
+        })
         return () => {
             socketConnection.disconnect()
         }
@@ -74,5 +78,12 @@ export function useSocket(token?: string) {
     // Function to clear error
     const clearSocketError = () => setSocketError(null)
 
-    return { socket, allUsers, userCount, socketError, clearSocketError }
+    return {
+        socket,
+        allUsers,
+        userCount,
+        socketError,
+        clearSocketError,
+        messages,
+    }
 }

--- a/src/components/page/ChatSection.tsx
+++ b/src/components/page/ChatSection.tsx
@@ -1,8 +1,43 @@
 "use client"
-import React from "react"
+import React, { useState, useEffect } from "react"
 import { Hash, Lock, Smile, Play } from "lucide-react"
 
-export default function ChatSection({ activeRoomData, openStickerModal }: any) {
+export default function ChatSection({
+    activeRoomData,
+    openStickerModal,
+    socket,
+    currentUser,
+    messages: allMessages = [],
+}: any) {
+    const [message, setMessage] = useState("")
+
+    // Filter messages for current room
+    const roomMessages = allMessages.filter(
+        (msg: any) => msg.cid === activeRoomData?.id
+    )
+
+    const handleSendMessage = () => {
+        if (!message.trim() || !socket || !currentUser || !activeRoomData)
+            return
+
+        const messageData = {
+            cid: activeRoomData.id,
+            message: message.trim(),
+        }
+
+        console.log("Sending message:", messageData)
+        socket.emit("send_message", messageData)
+        setMessage("")
+    }
+
+    const handleKeyPress = (e: React.KeyboardEvent) => {
+        if (e.key === "Enter" && !e.shiftKey) {
+            e.preventDefault()
+            handleSendMessage()
+        }
+    }
+
+    // Messages are now handled centrally in useSocket hook
     return (
         <div className="flex-1 bg-purple-100 rounded-lg shadow-lg flex flex-col">
             {activeRoomData && (
@@ -25,17 +60,59 @@ export default function ChatSection({ activeRoomData, openStickerModal }: any) {
                             </div>
                         </div>
                     </div>
-                    {/* Room Content Area */}
-                    <div className="flex-1 p-6 flex items-center justify-center">
-                        <p className="text-purple-600 font-serif text-center text-lg">
-                            Welcome to {activeRoomData.name}
-                        </p>
+                    {/* Messages Area */}
+                    <div className="flex-1 p-4 overflow-y-auto">
+                        {roomMessages.length === 0 ? (
+                            <div className="flex items-center justify-center h-full">
+                                <p className="text-purple-600 font-serif text-center text-lg">
+                                    Welcome to {activeRoomData.name}
+                                </p>
+                            </div>
+                        ) : (
+                            <div className="space-y-3">
+                                {roomMessages.map((msg: any, index: number) => (
+                                    <div
+                                        key={index}
+                                        className="bg-white rounded-lg p-3 shadow-sm"
+                                    >
+                                        <div className="flex items-start gap-3">
+                                            <div className="w-8 h-8 bg-purple-500 rounded-full flex items-center justify-center text-white text-sm font-bold">
+                                                {msg.user?.name?.[0] ||
+                                                    msg.user_id?.[0] ||
+                                                    "U"}
+                                            </div>
+                                            <div className="flex-1">
+                                                <div className="flex items-center gap-2 mb-1">
+                                                    <span className="font-semibold text-purple-900">
+                                                        {msg.user?.name ||
+                                                            msg.user_id ||
+                                                            "Unknown User"}
+                                                    </span>
+                                                    <span className="text-xs text-purple-500">
+                                                        {new Date(
+                                                            msg.timestamp ||
+                                                                Date.now()
+                                                        ).toLocaleTimeString()}
+                                                    </span>
+                                                </div>
+                                                <p className="text-purple-800">
+                                                    {msg.data}
+                                                </p>
+                                            </div>
+                                        </div>
+                                    </div>
+                                ))}
+                            </div>
+                        )}
                     </div>
                     {/* Message Input */}
                     <div className="border-t border-purple-300 p-4 bg-white rounded-b-lg">
                         <div className="flex gap-2">
                             <input
                                 type="text"
+                                value={message}
+                                onChange={(e) => setMessage(e.target.value)}
+                                onKeyPress={handleKeyPress}
                                 placeholder="Type a message..."
                                 className="flex-1 bg-purple-100 border border-purple-300 rounded-lg px-4 py-3 text-purple-900 placeholder-purple-500 focus:outline-none focus:border-purple-600"
                             />
@@ -46,7 +123,12 @@ export default function ChatSection({ activeRoomData, openStickerModal }: any) {
                             >
                                 <Smile size={20} />
                             </button>
-                            <button className="bg-purple-500 hover:bg-purple-600 text-white p-3 rounded-lg transition-colors flex items-center justify-center">
+                            <button
+                                onClick={handleSendMessage}
+                                disabled={!message.trim()}
+                                className="bg-purple-500 hover:bg-purple-600 disabled:bg-purple-300 text-white p-3 rounded-lg transition-colors flex items-center justify-center"
+                                title="Send Message"
+                            >
                                 <Play size={20} fill="currentColor" />
                             </button>
                         </div>


### PR DESCRIPTION
This pull request introduces real-time chat functionality by centralizing message handling through the `useSocket` hook and updating the `ChatSection` component to display and send messages for each room. Messages are now managed in a single place and passed down as props, ensuring consistent updates across the app.

**Real-time messaging integration:**

* Added a `messages` state to the `useSocket` hook, which is updated whenever a new message is received via the `receive_msg` socket event. The hook now returns the `messages` array alongside other socket-related data. [[1]](diffhunk://#diff-0696994e18d51e61c861fe5ec10b5a5c1de6c0bbbe490d6f5e04751021de49d2R11) [[2]](diffhunk://#diff-0696994e18d51e61c861fe5ec10b5a5c1de6c0bbbe490d6f5e04751021de49d2L60-R63) [[3]](diffhunk://#diff-0696994e18d51e61c861fe5ec10b5a5c1de6c0bbbe490d6f5e04751021de49d2L81-R90)
* Updated both `ChatRoom` and `YOTTChatRooms` components to retrieve `messages` from `useSocket` and pass them as props to child components. [[1]](diffhunk://#diff-d27a8260c8576637afe3b96a898425933d108ffa8cf9c854d6544f9752e81f2fL29-R36) [[2]](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bL29-R36) [[3]](diffhunk://#diff-d27a8260c8576637afe3b96a898425933d108ffa8cf9c854d6544f9752e81f2fR124-R126)

**Chat UI and message handling:**

* Refactored the `ChatSection` component to accept `messages`, `socket`, and `currentUser` as props. It now filters and displays messages relevant to the active chat room and renders them in a scrollable area. [[1]](diffhunk://#diff-f187fed6ca32415cb60d59fd34a96d5a3f551ab4207b99a28ace96f064932efaL2-R40) [[2]](diffhunk://#diff-f187fed6ca32415cb60d59fd34a96d5a3f551ab4207b99a28ace96f064932efaL28-R115)
* Implemented message sending functionality in `ChatSection`, allowing users to send messages with the send button or by pressing Enter. The input is cleared after sending, and the send button is disabled if the input is empty. [[1]](diffhunk://#diff-f187fed6ca32415cb60d59fd34a96d5a3f551ab4207b99a28ace96f064932efaL2-R40) [[2]](diffhunk://#diff-f187fed6ca32415cb60d59fd34a96d5a3f551ab4207b99a28ace96f064932efaL49-R131)