### PR TITLE
add display member

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -998,6 +998,7 @@
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -1934,6 +1935,7 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.27.2.tgz",
       "integrity": "sha512-5SYSgFKSyhCbk6SrXyMpqjb5+MQBgfvEKE/OC+PujcY34sOpqtr+0AZQtPYx5IA6VxynQ7rUPCtKzyovpj9Bpg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -1968,6 +1970,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1977,6 +1980,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },

--- a/src/components/hook/useSocket.ts
+++ b/src/components/hook/useSocket.ts
@@ -15,7 +15,7 @@ export function useSocket(token?: string) {
 
     useEffect(() => {
         if (!token) return
-        const socketConnection = io("http://localhost:8000", {
+        const socketConnection = io("https://api.yott.me/", {
             autoConnect: true,
             reconnection: true,
             reconnectionDelay: 1000,

--- a/src/components/page/ChatSection.tsx
+++ b/src/components/page/ChatSection.tsx
@@ -198,7 +198,19 @@ export default function ChatSection({
         (msg: Message) => msg.cid === activeRoomData?.cid
     )
 
-    const roomMessages = [...(chatData || []), ...socketRoomMessages]
+    const roomMessages = [
+    ...(chatData || []),
+    ...socketRoomMessages.filter(
+        (socketMsg: Message) => !(chatData || []).some(
+            (chatMsg: Message) =>
+                // Deduplicate by a composite key (sender id + timestamp + message text)
+                chatMsg.s_id === socketMsg.s_id &&
+                new Date(chatMsg.timestamp).getTime() ===
+                    new Date(socketMsg.timestamp).getTime() &&
+                chatMsg.message === socketMsg.message
+        )
+    ),
+]
 
     // Auto-scroll behavior: when a new realtime message arrives, or when initial
     // chatData is loaded, scroll to bottom. Do NOT jump when older pages are prepended.

--- a/src/components/page/JoinGroupModal.tsx
+++ b/src/components/page/JoinGroupModal.tsx
@@ -117,8 +117,8 @@ const JoinGroupModal = ({
 
   if (!isOpen) return null
 
-  const existingCids = new Set((groupRooms || []).map((r: Chat) => r.cid))
-  const groups = (allChats || []).filter((c: Chat) => !!c.is_groupchat && !existingCids.has(c.cid))
+  const existingCids = new Set((groupRooms.filter(val=>val.is_own) || []).map((r: Chat) => r.cid))
+  const groups = (allChats || []).filter((c: Chat) => !!c.is_groupchat && !existingCids.has(c.cid) && !c.is_own)
   const filtered = groups.filter((g: Chat) => (g.name || `Channel ${g.cid}`).toLowerCase().includes(searchTerm.toLowerCase()))
 
   return (

--- a/src/components/page/JoinGroupModal.tsx
+++ b/src/components/page/JoinGroupModal.tsx
@@ -112,13 +112,13 @@ const JoinGroupModal = ({
   onJoinGroup: (groupCode: number) => void
   groupRooms: Chat[]
 }) => {
-  const { allChats, loading, error } = useAllChatRooms()
+
   const [searchTerm, setSearchTerm] = useState("")
 
   if (!isOpen) return null
 
   const existingCids = new Set((groupRooms.filter(val=>val.is_own) || []).map((r: Chat) => r.cid))
-  const groups = (allChats || []).filter((c: Chat) => !!c.is_groupchat && !existingCids.has(c.cid) && !c.is_own)
+  const groups = (groupRooms || []).filter((c: Chat) => !!c.is_groupchat && !existingCids.has(c.cid))
   const filtered = groups.filter((g: Chat) => (g.name || `Channel ${g.cid}`).toLowerCase().includes(searchTerm.toLowerCase()))
 
   return (
@@ -144,14 +144,7 @@ const JoinGroupModal = ({
           </div>
         </div>
 
-        {loading ? (
-          <div className="flex items-center justify-center py-8">
-            <div className="loading-spinner mr-2" />
-            <span className="text-white">Loading channels...</span>
-          </div>
-        ) : error ? (
-          <p className="text-sm text-red-300">{error}</p>
-        ) : filtered.length === 0 ? (
+        {filtered.length === 0 ? (
           <p className="text-sm text-white/90">No channels available</p>
         ) : (
           <div className="space-y-2 max-h-64 overflow-y-auto">

--- a/src/components/page/JoinGroupModal.tsx
+++ b/src/components/page/JoinGroupModal.tsx
@@ -2,8 +2,104 @@
 import React, { useEffect, useState } from "react";
 import { Chat } from "@/types/chat";
 import useAllChatRooms from "@/components/hook/useAllChatRooms";
-import { Search, X } from "lucide-react";
+import { Search, X, Users } from "lucide-react";
 import { UserAvatar } from "../userAvatar";
+import { Person } from "@/types/person";
+import { apiClient } from "@/lib/apiClient";
+import { useSession } from "next-auth/react";
+import { useSocket } from "@/components/hook/useSocket";
+
+// Component to display group member preview
+const GroupMemberPreview = ({ groupId }: { groupId: number }) => {
+  const { data: session } = useSession();
+  const { socket, currentGroupUser } = useSocket(session?.idToken);
+  const [members, setMembers] = useState<Person[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!socket || !groupId) return;
+
+    setLoading(true);
+
+    // Listen for chat_member events
+    const handleChatMember = (memberData: Person[]) => {
+      console.log("Received chat members:", memberData);
+      setMembers(memberData || []);
+      setLoading(false);
+    };
+    console.log("Requesting members for groupId:", groupId);
+    // Request group members via socket
+    socket.emit("chat_member", groupId);
+
+    // Listen for the response
+    console.log("Listening for chat_member_update for groupId:", groupId);
+    socket.on("chat_member_update", handleChatMember);
+    return () => {
+      console.log("Stopping listening for chat_member_update for groupId:", groupId);
+      socket.off("chat_member_update", handleChatMember);
+    };
+  }, [socket, groupId]);
+
+  // Also update when currentGroupUser changes (for current active room)
+  useEffect(() => {
+    if (currentGroupUser && currentGroupUser.length > 0) {
+      setMembers(currentGroupUser);
+      setLoading(false);
+    }
+  }, [currentGroupUser]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center gap-2 text-white/60 text-xs">
+        <Users size={14} />
+        <span>Loading members...</span>
+      </div>
+    );
+  }
+
+  if (members.length === 0) {
+    return (
+      <div className="flex items-center gap-2 text-white/60 text-xs">
+        <Users size={14} />
+        <span>No members</span>
+      </div>
+    );
+  }
+
+  const displayedMembers = members.slice(0, 5);
+  const remainingCount = Math.max(0, members.length - 5);
+
+  return (
+    <div className="flex items-center gap-2">
+      <Users size={14} className="text-white/60" />
+      <div className="flex items-center gap-1">
+        <div className="flex -space-x-2">
+          {displayedMembers.map((member, index) => (
+            <div
+              key={member.uid || index}
+              className="border-2 border-purple-600 rounded-full"
+              style={{ zIndex: displayedMembers.length - index }}
+            >
+              <UserAvatar
+                name={member.given_name || member.display_name || 'Unknown'}
+                isOnline={member.status === 'online'}
+                size="xs"
+              />
+            </div>
+          ))}
+        </div>
+        {remainingCount > 0 && (
+          <span className="text-xs text-white/80 ml-2 font-medium">
+            +{remainingCount}
+          </span>
+        )}
+        <span className="text-xs text-white/60 ml-1">
+          ({members.length} member{members.length !== 1 ? 's' : ''})
+        </span>
+      </div>
+    </div>
+  );
+};
 
 const JoinGroupModal = ({
   isOpen,
@@ -60,12 +156,13 @@ const JoinGroupModal = ({
         ) : (
           <div className="space-y-2 max-h-64 overflow-y-auto">
             {filtered.map((room: Chat) => (
-              <div key={room.cid} className="flex items-center justify-between p-2 rounded">
-                <div className="flex items-center gap-3">
+              <div key={room.cid} className="flex items-center justify-between p-3 rounded-lg hover:bg-purple-500/20 transition-colors">
+                <div className="flex items-center gap-3 flex-1 min-w-0">
                   <UserAvatar name={room.name || `Channel ${room.cid}`} isOnline={false} size="md" />
-                  <div>
-                    <div className="font-medium text-white">{room.name || `Channel ${room.cid}`}</div>
-                    <div className="text-xs text-white/60">ID: {room.cid}</div>
+                  <div className="flex-1 min-w-0">
+                    <div className="font-medium text-white truncate">{room.name || `Channel ${room.cid}`}</div>
+                    <div className="text-xs text-white/60 mb-1">ID: {room.cid}</div>
+                    <GroupMemberPreview groupId={room.cid} />
                   </div>
                 </div>
                 <div className="flex items-center gap-2">

--- a/src/components/page/Sidebar.tsx
+++ b/src/components/page/Sidebar.tsx
@@ -84,7 +84,7 @@ export default function Sidebar({
                             GroupChat
                         </h3>
                         <div className="space-y-1">
-                            {groupRooms.map((room: Chat) => (
+                            {groupRooms.filter((val : Chat)=>val.is_own).map((room: Chat) => (
                                 <ChatRoomItem
                                     key={room.cid}
                                     room={room}
@@ -102,7 +102,7 @@ export default function Sidebar({
                             Direct Messages
                         </h3>
                         <div className="space-y-1">
-                            {privateRooms.map((room: Chat) => (
+                            {privateRooms.filter((val : Chat)=>val.is_own).map((room: Chat) => (
                                 <ChatRoomItem
                                     key={room.cid}
                                     room={room}

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -3,4 +3,5 @@ export interface Chat {
     name: string
     is_groupchat: boolean
     unread: number
+    is_own? : boolean
 }


### PR DESCRIPTION
This pull request enhances the group join experience by adding a real-time group member preview to the group selection list in the `JoinGroupModal`. Users can now see a summary of group members (including avatars and online status) for each group before joining, with live updates via socket events.

**New group member preview feature:**
- Added a `GroupMemberPreview` component that displays up to five member avatars, online status, and a count of total members for a given group, updating in real time using socket events. (`src/components/page/JoinGroupModal.tsx`, [src/components/page/JoinGroupModal.tsxL5-R102](diffhunk://#diff-ede027afcdbe6ccc53b4d4218075678d53963a55c7bf91f5a1b41800dd3a83d9L5-R102))
- Integrated `GroupMemberPreview` into each group listing in the join group modal, improving the UI to show member details directly below the group name and ID. (`src/components/page/JoinGroupModal.tsx`, [src/components/page/JoinGroupModal.tsxL63-R165](diffhunk://#diff-ede027afcdbe6ccc53b4d4218075678d53963a55c7bf91f5a1b41800dd3a83d9L63-R165))